### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Gemfile.lock
 doc/*
 pkg/*
+coverage
+spec/cassettes/*


### PR DESCRIPTION
Running rake creates a coverage directory and initializes some cassettes for vcr. Would like to keep the working tree clean after running tests.
