### PR TITLE
Issues while using Mongoid

### DIFF
--- a/lib/pupa/models/model.rb
+++ b/lib/pupa/models/model.rb
@@ -36,7 +36,7 @@ module Pupa
       attr_reader :extras
       # @return [String] The underscored, lowercase form of the object's class.
       attr_accessor :_type
-      # @return [Moped::BSON::Document,nil] The object's matching document in
+      # @return [BSON::Document,nil] The object's matching document in
       #   the database. Set before persisting the object to the database.
       attr_accessor :document
 
@@ -129,9 +129,9 @@ module Pupa
 
     # Sets the object's ID.
     #
-    # @param [String,Moped::BSON::ObjectId] id an ID
+    # @param [String,BSON::ObjectId] id an ID
     def _id=(id)
-      @_id = id.to_s # in case of Moped::BSON::ObjectId
+      @_id = id.to_s # in case of BSON::ObjectId
     end
 
     # Sets the extras.

--- a/pupa.gemspec
+++ b/pupa.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday_middleware', '~> 0.9.0')
   s.add_runtime_dependency('json-schema', '~> 2.1.3')
   s.add_runtime_dependency('mail')
-  s.add_runtime_dependency('moped', '~> 1.5.1')
+  s.add_runtime_dependency('moped', '~> 2.0.0.beta')
   s.add_runtime_dependency('oj', '~> 2.1')
 
   s.add_development_dependency('coveralls')

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -146,7 +146,7 @@ describe Pupa::Model do
     end
 
     it 'should coerce the _id to a string' do
-      object._id = Moped::BSON::ObjectId.new
+      object._id = BSON::ObjectId.new
       object._id.should be_a(String)
     end
   end


### PR DESCRIPTION
Hey James,

Thanks for all your help. I tried using mongoid with pupa-ruby but ran into some dependency issues which I managed to address with this PR by bumping the version of moped. Moped is still in beta so I'm not sure if you're interested in merging it but someone else might this find helpful. 

The second issue was the following strack trace. Any thoughts on why there might be a collision?

``` ruby
Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor.rb:218:in `dump_scraped_object': undefined method `gsub' for nil:NilClass (NoMethodError)
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor.rb:114:in `block (2 levels) in dump_scraped_objects'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor/yielder.rb:21:in `block in each'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor/yielder.rb:20:in `loop'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor/yielder.rb:20:in `each'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor.rb:112:in `block in dump_scraped_objects'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor/document_store/file_store.rb:98:in `pipelined'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/processor.rb:111:in `dump_scraped_objects'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/runner.rb:193:in `block in run'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/runner.rb:192:in `each'
        from /Users/sunnyjuneja/.rvm/gems/ruby-2.1.0/bundler/gems/pupa-ruby-822595aa853f/lib/pupa/runner.rb:192:in `run'
        from alamedaco.rb:147:in `<main>' 
```

You should be able to replicate this issue with the following settings:

``` ruby
require 'pupa'
require 'mongoid'

Mongoid.load!("mongoid.yml", :development)

class Category
  include Pupa::Model
  include Mongoid::Document
end

class CatProcessor < Pupa::Processor
  def scrape_categories
    category  = Category.new
    dispatch category
  end
end

CatProcessor.add_scraping_task(:categories)
runner = Pupa::Runner.new(CatProcessor)
runner.run(ARGV)
```

``` ruby
# Gemfile
source "https://rubygems.org"

gem 'pupa', '~> 0.0.13', git: 'https://github.com/whatasunnyday/pupa-ruby/', branch: 'update-moped'
gem 'nokogiri', '~> 1.6.1'
gem 'mongoid', '4.0.0.beta1', git: 'https://github.com/mongoid/mongoid'
```

``` ruby
# mongoid.yml
development:
  sessions:
    default:
      database: pupa
      hosts:
        - localhost:27017
```
